### PR TITLE
Fix tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2,27 +2,28 @@
 jobs:
 - name: push-aws-broker
   plan:
-  - aggregate:
-    - get: aws-broker-app
-      trigger: true
+  - get: aws-broker-app
+    trigger: true
+  - task: run_tests
+    file: aws-broker-app/ci/run_tests.yml
   - put: deploy-aws-broker-app
     params:
       manifest: aws-broker-app/manifest.yml
       path: aws-broker-app
       current_app_name: aws-broker
       environment_variables:
-        AUTH_PASS: {{ auth-pass }}
-        AUTH_USER: {{ auth-user }}
-        AWS_ACCESS_KEY_ID: {{ aws-access-key-id }}
-        AWS_SECRET_ACCESS_KEY: {{ aws-secret-access-key }}
-        DB_NAME: {{ db-name }}
-        DB_PASS: {{ db-pass }}
-        DB_PORT: {{ db-port }}
-        DB_SSLMODE: {{ db-sslmode }}
-        DB_TYPE: {{ db-type }}
-        DB_URL: {{ db-url }}
-        DB_USER: {{ db-user }}
-        ENC_KEY: {{ enc-key }}
+        AUTH_PASS: {{auth-pass}}
+        AUTH_USER: {{auth-user}}
+        AWS_ACCESS_KEY_ID: {{aws-access-key-id}}
+        AWS_SECRET_ACCESS_KEY: {{aws-secret-access-key}}
+        DB_NAME: {{db-name}}
+        DB_PASS: {{db-pass}}
+        DB_PORT: {{db-port}}
+        DB_SSLMODE: {{db-sslmode}}
+        DB_TYPE: {{db-type}}
+        DB_URL: {{db-url}}
+        DB_USER: {{db-user}}
+        ENC_KEY: {{enc-key}}
 
     on_failure:
       put: slack

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e -x
+
+export GOPATH=$(pwd)/gopath
+export PATH=$PATH:$GOPATH/bin
+
+go get github.com/tools/godep
+
+cd gopath/src/github.com/18F/aws-broker
+
+cp secrets-test.yml secrets.yml
+
+godep get
+godep go build ./...
+godep go test ./...

--- a/ci/run_tests.yml
+++ b/ci/run_tests.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: 1.6-wheezy
+
+inputs:
+  - name: aws-broker-app
+    path: gopath/src/github.com/18F/aws-broker
+
+run:
+  path: gopath/src/github.com/18F/aws-broker/ci/run_tests.sh

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,18 +1,5 @@
 ---
 applications:
 - name: aws-broker
+  buildpack: go_buildpack
   memory: 256M
-  buildpack: https://github.com/cloudfoundry/go-buildpack#v1.7.0
-  env:
-    AUTH_USER: user
-    AUTH_PASS: pass
-    DB_URL: 10.244.0.30
-    DB_NAME: rdsbroker
-    DB_USER: rds
-    DB_PASS: rds
-    DB_PORT: 5524
-    DB_TYPE: postgres
-    DB_SSLMODE: verify-ca
-    ENC_KEY: "12345678901234567890123456789012"
-    AWS_ACCESS_KEY_ID: AKID1234567890
-    AWS_SECRET_ACCESS_KEY: MY-SECRET-KEY

--- a/secrets-test.yml
+++ b/secrets-test.yml
@@ -1,0 +1,3 @@
+rds:
+  service_id: "db80ca29-2d1b-4fbc-aad3-d03c0bfa7593"
+  plans: []

--- a/wercker.yml
+++ b/wercker.yml
@@ -22,4 +22,5 @@ build:
     - script:
         name: godep go test
         code: |
+          cp secrets-test.yml secrets.yml
           godep go test ./...


### PR DESCRIPTION
The tests fail now, since they require a `secrets.yml` file to run. Using `secrets-example.yml` fails because the application tries to connect to the databases in the config file. This adds a `secrets-test.yml` file with no plans to avoid attempting to connect to a database during tests. This also cleans up the concourse pipeline (which apparently crashes on whitespace in interpolated variable names) and runs tests before deploying to cloud foundry.

cc @sharms @dlapiduz