### PR TITLE
Verify AWS credentials and use region from environment.

### DIFF
--- a/config/settings.go
+++ b/config/settings.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"github.com/18F/aws-broker/common"
 	"log"
 	"os"
@@ -28,6 +29,13 @@ func (s *Settings) LoadFromEnv() error {
 	dbConfig.DbName = os.Getenv("DB_NAME")
 	if dbConfig.Sslmode = os.Getenv("DB_SSLMODE"); dbConfig.Sslmode == "" {
 		dbConfig.Sslmode = "require"
+	}
+
+	// Ensure AWS credentials exist in environment
+	for _, key := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"} {
+		if os.Getenv(key) == "" {
+			return fmt.Errorf("Must set environment variable %s", key)
+		}
 	}
 
 	if os.Getenv("DB_PORT") != "" {

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -101,7 +101,7 @@ type dedicatedDBAdapter struct {
 }
 
 func (d *dedicatedDBAdapter) createDB(i *RDSInstance, password string) (base.InstanceState, error) {
-	svc := rds.New(session.New(), aws.NewConfig().WithRegion("us-east-1"))
+	svc := rds.New(session.New(), aws.NewConfig())
 	var rdsTags []*rds.Tag
 
 	for k, v := range i.Tags {
@@ -154,7 +154,7 @@ func (d *dedicatedDBAdapter) bindDBToApp(i *RDSInstance, password string) (map[s
 	// First, we need to check if the instance is up and available before binding.
 	// Only search for details if the instance was not indicated as ready.
 	if i.State != base.InstanceReady {
-		svc := rds.New(session.New(), aws.NewConfig().WithRegion("us-east-1"))
+		svc := rds.New(session.New(), aws.NewConfig())
 		params := &rds.DescribeDBInstancesInput{
 			DBInstanceIdentifier: aws.String(i.Database),
 			// MaxRecords: aws.Long(1),
@@ -212,7 +212,7 @@ func (d *dedicatedDBAdapter) bindDBToApp(i *RDSInstance, password string) (map[s
 }
 
 func (d *dedicatedDBAdapter) deleteDB(i *RDSInstance) (base.InstanceState, error) {
-	svc := rds.New(session.New(), aws.NewConfig().WithRegion("us-east-1"))
+	svc := rds.New(session.New(), aws.NewConfig())
 	params := &rds.DeleteDBInstanceInput{
 		DBInstanceIdentifier: aws.String(i.Database), // Required
 		// FinalDBSnapshotIdentifier: aws.String("String"),


### PR DESCRIPTION
[Resolves https://github.com/18F/cg-atlas/issues/55]

Note--we could also capture the environment in `config.Settings` and pass it around throughout the codebase if folks would prefer, but I figured that allowing the AWS SDK to pull its configuration from the environment is more consistent with what we're already doing.

cc @sharms @jcscottiii 