### PR TITLE
Update pipeline with resource_types

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -91,7 +91,7 @@ jobs:
       params:
         text: |
           :x: FAILED to deploy aws-broker on staging
-          <https://ci.cloud.gov/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          <$ATC_EXTERNAL_URL/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: {{slack-channel}}
         username: {{slack-username}}
         icon_url: {{slack-icon-url}}
@@ -100,7 +100,7 @@ jobs:
       params:
         text: |
           :white_check_mark: Successfully deployed aws-broker on staging
-          <https://ci.cloud.gov/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          <$ATC_EXTERNAL_URL/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: {{slack-channel}}
         username: {{slack-username}}
         icon_url: {{slack-icon-url}}
@@ -237,7 +237,7 @@ jobs:
       params:
         text: |
           :x: FAILED to deploy aws-broker on production
-          <https://ci.cloud.gov/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          <$ATC_EXTERNAL_URL/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: {{slack-channel}}
         username: {{slack-username}}
         icon_url: {{slack-icon-url}}
@@ -246,7 +246,7 @@ jobs:
       params:
         text: |
           :white_check_mark: Successfully deployed aws-broker on production
-          <https://ci.cloud.gov/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+          <$ATC_EXTERNAL_URL/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
         channel: {{slack-channel}}
         username: {{slack-username}}
         icon_url: {{slack-icon-url}}
@@ -331,6 +331,12 @@ resources:
   type: slack-notification
   source:
     url: {{slack-webhook-url}}
+
+resource_types:
+- name: slack-notification
+  type: docker-image
+    source:
+        repository: cfcommunity/slack-notification-resource
 
 staging-cf-creds: &staging-cf-creds
   CF_API_URL: {{staging-cf-api-url}}


### PR DESCRIPTION
For review, make non built-in resource types explicit, rather than relying on them being installed in Concourse. Has been fly'd.
@18F/cloud-gov-ops