### PR TITLE
FIx Oracle uri [WIP]

### DIFF
--- a/ci/smoke-tests/smoke-tests.sh
+++ b/ci/smoke-tests/smoke-tests.sh
@@ -28,7 +28,7 @@ elif [ $DB_TYPE = "oracle-se1" ] || [ $DB_TYPE = "oracle-se2" ] || [ $DB_TYPE = 
   SQL_HOST=$(echo $VCAP_SERVICES | $JQ -r '."aws-rds"[0].credentials.host')
   SQL_USER=$(echo $VCAP_SERVICES | $JQ -r '."aws-rds"[0].credentials.username')
   SQL_PASS=$(echo $VCAP_SERVICES | $JQ -r '."aws-rds"[0].credentials.password')
-  SQL_DB=$(echo $VCAP_SERVICES | $JQ -r '."aws-rds"[0].credentials.sid')
+  SQL_DB=$(echo $VCAP_SERVICES | $JQ -r '."aws-rds"[0].credentials.db_name')
   # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ConnectToOracleInstance.html notes
   # that this connection string may fail if SQL_HOST string is > 63 chars, but
   # works OK with 80 chars in testing

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -82,29 +82,30 @@ func (i *RDSInstance) getPassword(key string) (string, error) {
 
 func (i *RDSInstance) getCredentials(password string) (map[string]string, error) {
 	var credentials map[string]string
-  dbScheme := switch i.DbType {
-	  case "postgres", "mysql":
-      i.DbType
-	  case "oracle-se1", "oracle-se2", "oracle-ee":
-      "oracle"
-    default:
-      return nil, errors.New("Cannot generate credentials for unsupported db type: " + i.DbType)
-  }
-  uri := fmt.Sprintf("%s://%s:%s@%s:%d/%s",
-			dbScheme,
-			i.Username,
-			password,
-			i.Host,
-			i.Port,
-			i.FormatDBName())
+	switch i.DbType {
+	case "postgres", "mysql":
+		dbScheme := i.DbType
+	case "oracle-se1", "oracle-se2", "oracle-ee":
+		dbScheme := "oracle"
+	default:
+		return nil, errors.New("Cannot generate credentials for unsupported db type: " + i.DbType)
+	}
+	uri := fmt.Sprintf("%s://%s:%s@%s:%d/%s",
+		dbScheme,
+		i.Username,
+		password,
+		i.Host,
+		i.Port,
+		i.FormatDBName())
 
 	credentials = map[string]string{
-			"uri":      uri,
-			"username": i.Username,
-			"password": password,
-			"host":     i.Host,
-			"port":     strconv.FormatInt(i.Port, 10),
-			"db_name":  i.FormatDBName(),
+		"uri":      uri,
+		"username": i.Username,
+		"password": password,
+		"host":     i.Host,
+		"port":     strconv.FormatInt(i.Port, 10),
+		"db_name":  i.FormatDBName(),
+	}
 	return credentials, nil
 }
 

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -81,59 +81,30 @@ func (i *RDSInstance) getPassword(key string) (string, error) {
 }
 
 func (i *RDSInstance) getCredentials(password string) (map[string]string, error) {
-	/*
-		What is the correct format for Oracle?
-			https://msdn.microsoft.com/en-us/library/dd787819.aspx
-			oracledb://User=[USER_NAME];Password=[PASSWORD]@[NET_SERVICE_NAME]?PollingId=[POLLING_ID]
-			http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ConnectToOracleInstance.html
-			'mydbusr@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=<dns name of db instance>)
-			(PORT=<listener port>))(CONNECT_DATA=(SID=<database name>)))
-
-			sqlplus 'mydbusr@(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=<dns name of db instance>)(PORT=<listener port>))(CONNECT_DATA=(SID=<database name>)))'
-
-
-			https://www.connectionstrings.com/oracle/
-			SERVER=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=MyHost)(PORT=MyPort))(CONNECT_DATA=(SERVICE_NAME=MyOracleSID)));
-			uid=myUsername;pwd=myPassword;
-	*/
 	var credentials map[string]string
-	switch i.DbType {
-	case "postgres", "mysql":
-		uri := fmt.Sprintf("%s://%s:%s@%s:%d/%s",
-			i.DbType,
+  dbScheme := switch i.DbType {
+	  case "postgres", "mysql":
+      i.DbType
+	  case "oracle-se1", "oracle-se2", "oracle-ee":
+      "oracle"
+    default:
+      return nil, errors.New("Cannot generate credentials for unsupported db type: " + i.DbType)
+  }
+  uri := fmt.Sprintf("%s://%s:%s@%s:%d/%s",
+			dbScheme,
 			i.Username,
 			password,
 			i.Host,
 			i.Port,
 			i.FormatDBName())
 
-		credentials = map[string]string{
+	credentials = map[string]string{
 			"uri":      uri,
 			"username": i.Username,
 			"password": password,
 			"host":     i.Host,
 			"port":     strconv.FormatInt(i.Port, 10),
 			"db_name":  i.FormatDBName(),
-		}
-	case "oracle-se1", "oracle-se2", "oracle-ee":
-		uri := fmt.Sprintf("oracledb://User=%s;Password=%s@%s:%d/%s",
-			i.Username,
-			password,
-			i.Host,
-			i.Port,
-			i.FormatDBName())
-
-		credentials = map[string]string{
-			"uri":      uri,
-			"username": i.Username,
-			"password": password,
-			"host":     i.Host,
-			"port":     strconv.FormatInt(i.Port, 10),
-			"sid":      i.FormatDBName(),
-		}
-	default:
-		return nil, errors.New("Cannot generate credentials for unsupported db type: " + i.DbType)
-	}
 	return credentials, nil
 }
 

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -81,12 +81,13 @@ func (i *RDSInstance) getPassword(key string) (string, error) {
 }
 
 func (i *RDSInstance) getCredentials(password string) (map[string]string, error) {
+	var dbScheme string
 	var credentials map[string]string
 	switch i.DbType {
 	case "postgres", "mysql":
-		dbScheme := i.DbType
+		dbScheme = i.DbType
 	case "oracle-se1", "oracle-se2", "oracle-ee":
-		dbScheme := "oracle"
+		dbScheme = "oracle"
 	default:
 		return nil, errors.New("Cannot generate credentials for unsupported db type: " + i.DbType)
 	}


### PR DESCRIPTION
and collapse a lot of logic since the format:

  "uri": "oracle://$user:$password@$hostname:$port/$name"

is the same as the mysql/postgres ones (from https://github.com/spring-cloud/spring-cloud-connectors/blob/master/spring-cloud-cloudfoundry-connector/src/test/resources/org/springframework/cloud/cloudfoundry/test-oracle-info-jdbc-url.json)

Also, the only scheme that matters is the one for our Oracle demo, `spring-music`, so removing comments.