### PR TITLE
Configure engine version and backup period.

### DIFF
--- a/catalog-template.yml
+++ b/catalog-template.yml
@@ -57,6 +57,7 @@ rds:
       redundant: false
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.postgres_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -84,6 +85,7 @@ rds:
       redundant: true
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.postgres_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -111,6 +113,7 @@ rds:
       redundant: false
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.postgres_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -138,6 +141,7 @@ rds:
       redundant: true
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.postgres_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -165,6 +169,7 @@ rds:
       redundant: false
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.postgres_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -192,6 +197,7 @@ rds:
       redundant: true
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.postgres_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -238,9 +244,11 @@ rds:
       instanceClass: db.m3.medium
       allocatedStorage: 10
       dbType: mysql
+      dbVersion: &mysql-version "5.7.21"
       redundant: false
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.mysql_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -265,9 +273,11 @@ rds:
       instanceClass: db.m3.medium
       allocatedStorage: 10
       dbType: mysql
+      dbVersion: *mysql-version
       redundant: true
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.mysql_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -292,9 +302,11 @@ rds:
       instanceClass: db.m3.large
       allocatedStorage: 10
       dbType: mysql
+      dbVersion: *mysql-version
       redundant: false
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.mysql_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -319,9 +331,11 @@ rds:
       instanceClass: db.m3.large
       allocatedStorage: 10
       dbType: mysql
+      dbVersion: *mysql-version
       redundant: true
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.mysql_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -346,9 +360,11 @@ rds:
       instanceClass: db.m3.xlarge
       allocatedStorage: 10
       dbType: mysql
+      dbVersion: *mysql-version
       redundant: false
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.mysql_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -373,9 +389,11 @@ rds:
       instanceClass: db.m3.xlarge
       allocatedStorage: 10
       dbType: mysql
+      dbVersion: *mysql-version
       redundant: true
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.mysql_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -404,6 +422,7 @@ rds:
       redundant: false
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.oracle_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:
@@ -432,6 +451,7 @@ rds:
       redundant: false
       encrypted: true
       storage_type: gp2
+      backup_retention_period: 14
       securityGroup: (( grab meta.aws_broker.mssql_security_group ))
       subnetGroup: (( grab meta.aws_broker.subnet_group ))
       tags:

--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -77,18 +77,20 @@ func (s RDSService) FetchPlan(planID string) (RDSPlan, response.Response) {
 // these fields are read from the catalog.yaml file, but are not rendered
 // in the catalog API endpoint.
 type RDSPlan struct {
-	Plan             `yaml:",inline" validate:"required"`
-	Adapter          string            `yaml:"adapter" json:"-" validate:"required"`
-	InstanceClass    string            `yaml:"instanceClass" json:"-"`
-	DbType           string            `yaml:"dbType" json:"-" validate:"required"`
-	LicenseModel     string            `yaml:"licenseModel" json:"-"`
-	Tags             map[string]string `yaml:"tags" json:"-" validate:"required"`
-	Redundant        bool              `yaml:"redundant" json:"-"`
-	Encrypted        bool              `yaml:"encrypted" json:"-"`
-	StorageType      string            `yaml:"storage_type" json:"-"`
-	AllocatedStorage int64             `yaml:"allocatedStorage" json:"-"`
-	SubnetGroup      string            `yaml:"subnetGroup" json:"-" validate:"required"`
-	SecurityGroup    string            `yaml:"securityGroup" json:"-" validate:"required"`
+	Plan                  `yaml:",inline" validate:"required"`
+	Adapter               string            `yaml:"adapter" json:"-" validate:"required"`
+	InstanceClass         string            `yaml:"instanceClass" json:"-"`
+	DbType                string            `yaml:"dbType" json:"-" validate:"required"`
+	DbVersion             string            `yaml:"dbVersion" json:"-"`
+	LicenseModel          string            `yaml:"licenseModel" json:"-"`
+	Tags                  map[string]string `yaml:"tags" json:"-" validate:"required"`
+	Redundant             bool              `yaml:"redundant" json:"-"`
+	Encrypted             bool              `yaml:"encrypted" json:"-"`
+	StorageType           string            `yaml:"storage_type" json:"-"`
+	AllocatedStorage      int64             `yaml:"allocatedStorage" json:"-"`
+	BackupRetentionPeriod int64             `yaml:"backup_retention_period" json:"-"" validate:"required"`
+	SubnetGroup           string            `yaml:"subnetGroup" json:"-" validate:"required"`
+	SecurityGroup         string            `yaml:"securityGroup" json:"-" validate:"required"`
 }
 
 // Catalog struct holds a collections of services

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -135,10 +135,14 @@ func (d *dedicatedDBAdapter) createDB(i *RDSInstance, password string) (base.Ins
 		StorageType:             aws.String(d.Plan.StorageType),
 		Tags:                    rdsTags,
 		PubliclyAccessible:      aws.Bool(false),
+		BackupRetentionPeriod:   aws.Int64(i.BackupRetentionPeriod),
 		DBSubnetGroupName:       &i.DbSubnetGroup,
 		VpcSecurityGroupIds: []*string{
 			&i.SecGroup,
 		},
+	}
+	if i.DbVersion != "" {
+		params.EngineVersion = aws.String(i.DbVersion)
 	}
 	if i.LicenseModel != "" {
 		params.LicenseModel = aws.String(i.LicenseModel)

--- a/services/rds/rdsinstance.go
+++ b/services/rds/rdsinstance.go
@@ -26,14 +26,16 @@ type RDSInstance struct {
 
 	ClearPassword string `sql:"-"`
 
-	Tags             map[string]string `sql:"-"`
-	DbSubnetGroup    string            `sql:"-"`
-	AllocatedStorage int64             `sql:"-"`
-	SecGroup         string            `sql:"-"`
+	Tags                  map[string]string `sql:"-"`
+	BackupRetentionPeriod int64             `sql:"-"`
+	DbSubnetGroup         string            `sql:"-"`
+	AllocatedStorage      int64             `sql:"-"`
+	SecGroup              string            `sql:"-"`
 
 	Adapter string `sql:"size(255)"`
 
 	DbType       string `sql:"size(255)"`
+	DbVersion    string `sql:"size(255)"`
 	LicenseModel string `sql:"size(255)"`
 }
 
@@ -128,6 +130,8 @@ func (i *RDSInstance) init(uuid string,
 
 	// Load AWS values
 	i.DbType = plan.DbType
+	i.DbVersion = plan.DbVersion
+	i.BackupRetentionPeriod = plan.BackupRetentionPeriod
 	i.DbSubnetGroup = plan.SubnetGroup
 	i.SecGroup = plan.SecurityGroup
 	i.LicenseModel = plan.LicenseModel


### PR DESCRIPTION
At the moment, we don't specify the engine version, which means rds picks a recent version for us. For some reason (I haven't been able to find this in the docs), rds defaults mysql versions to 5.6.x, even though 5.7.x is supported. This patch sets the mysql version to the latest in the 5.7.x series.

* Make backup period configurable
* Configure backup period to 14d for all non-shared plans
* Make engine version configurable but optional
* Set mysql engine version to latest for all non-shared plans