### PR TITLE
Update manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,3 +3,5 @@ applications:
 - name: aws-broker
   buildpack: go_buildpack
   memory: 256M
+  env:
+    GOVERSION: go1.12


### PR DESCRIPTION
Failing to push due to no goversion env var telling the buildpack which version to use.

[cause](https://ci.fr.cloud.gov/teams/main/pipelines/deploy-aws-broker/jobs/deploy-aws-broker-staging/builds/175)