### PR TITLE
modernized pipeline.

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -2,12 +2,11 @@
 jobs:
 - name: deploy-aws-broker-development
   plan:
-  - aggregate:
+  - in_parallel:
     - get: aws-broker-app
       resource: aws-broker-app-development
       trigger: true
     - get: pipeline-tasks
-
   - task: run_tests
     file: aws-broker-app/ci/run_tests.yml
 
@@ -113,7 +112,11 @@ jobs:
   - task: update-broker
     file: pipeline-tasks/register-service-broker.yml
     params:
-      <<: *development-cf-creds
+      CF_API_URL: {{development-cf-api-url}}
+      CF_USERNAME: {{development-cf-deploy-username}}
+      CF_PASSWORD: {{development-cf-deploy-password}}
+      CF_ORGANIZATION: {{development-cf-organization}}
+      CF_SPACE: {{development-cf-space}}
       BROKER_NAME: {{development-broker-name}}
       AUTH_USER: {{development-auth-user}}
       AUTH_PASS: {{development-auth-pass}}
@@ -122,7 +125,11 @@ jobs:
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
     params:
-      <<: *development-cf-creds
+      CF_API_URL: {{development-cf-api-url}}
+      CF_USERNAME: {{development-cf-deploy-username}}
+      CF_PASSWORD: {{development-cf-deploy-password}}
+      CF_ORGANIZATION: {{development-cf-organization}}
+      CF_SPACE: {{development-cf-space}}
       BROKER_NAME: {{development-broker-name}}
       AUTH_USER: {{development-auth-user}}
       AUTH_PASS: {{development-auth-pass}}
@@ -135,46 +142,62 @@ jobs:
     resource: aws-broker-app-development
     passed: [deploy-aws-broker-development]
     trigger: true
-  - aggregate:
-    - get: sqlclient-oracle-basiclite
-    - get: sqlclient-oracle-sqlplus
-    - get: sqlclient-postgres
-    - get: sqlclient-mysql
-  - aggregate:
-    - task: smoke-tests-postgres
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *development-cf-creds
-        SERVICE_PLAN: medium-psql
-        DB_TYPE: postgres
+  - in_parallel:
+      steps:
+      - task: smoke-tests-postgres
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{development-cf-api-url}}
+          CF_USERNAME: {{development-cf-deploy-username}}
+          CF_PASSWORD: {{development-cf-deploy-password}}
+          CF_ORGANIZATION: {{development-cf-organization}}
+          CF_SPACE: {{development-cf-space}}
+          SERVICE_PLAN: medium-psql
+          DB_TYPE: postgres
 
-    - task: smoke-tests-shared-postgres
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *development-cf-creds
-        SERVICE_PLAN: shared-psql
-        DB_TYPE: postgres
+      - task: smoke-tests-shared-postgres
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{development-cf-api-url}}
+          CF_USERNAME: {{development-cf-deploy-username}}
+          CF_PASSWORD: {{development-cf-deploy-password}}
+          CF_ORGANIZATION: {{development-cf-organization}}
+          CF_SPACE: {{development-cf-space}}
+          SERVICE_PLAN: shared-psql
+          DB_TYPE: postgres
 
-    - task: smoke-tests-mysql
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *development-cf-creds
-        SERVICE_PLAN: medium-mysql
-        DB_TYPE: mysql
+      - task: smoke-tests-mysql
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{development-cf-api-url}}
+          CF_USERNAME: {{development-cf-deploy-username}}
+          CF_PASSWORD: {{development-cf-deploy-password}}
+          CF_ORGANIZATION: {{development-cf-organization}}
+          CF_SPACE: {{development-cf-space}}
+          SERVICE_PLAN: medium-mysql
+          DB_TYPE: mysql
 
-    - task: smoke-tests-shared-mysql
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *development-cf-creds
-        SERVICE_PLAN: shared-mysql
-        DB_TYPE: mysql
+      - task: smoke-tests-shared-mysql
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{development-cf-api-url}}
+          CF_USERNAME: {{development-cf-deploy-username}}
+          CF_PASSWORD: {{development-cf-deploy-password}}
+          CF_ORGANIZATION: {{development-cf-organization}}
+          CF_SPACE: {{development-cf-space}}
+          SERVICE_PLAN: shared-mysql
+          DB_TYPE: mysql
 
-    - task: smoke-tests-oracle
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *development-cf-creds
-        SERVICE_PLAN: medium-oracle-se2
-        DB_TYPE: oracle-se2
+      - task: smoke-tests-oracle
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{development-cf-api-url}}
+          CF_USERNAME: {{development-cf-deploy-username}}
+          CF_PASSWORD: {{development-cf-deploy-password}}
+          CF_ORGANIZATION: {{development-cf-organization}}
+          CF_SPACE: {{development-cf-space}}
+          SERVICE_PLAN: medium-oracle-se2
+          DB_TYPE: oracle-se2
   on_success:
     put: slack
     params:
@@ -196,11 +219,10 @@ jobs:
 
 - name: deploy-aws-broker-staging
   plan:
-  - aggregate:
+  - in_parallel:
     - get: aws-broker-app
       trigger: true
     - get: pipeline-tasks
-
   - task: run_tests
     file: aws-broker-app/ci/run_tests.yml
 
@@ -306,7 +328,11 @@ jobs:
   - task: update-broker
     file: pipeline-tasks/register-service-broker.yml
     params:
-      <<: *staging-cf-creds
+      CF_API_URL: {{staging-cf-api-url}}
+      CF_USERNAME: {{staging-cf-deploy-username}}
+      CF_PASSWORD: {{staging-cf-deploy-password}}
+      CF_ORGANIZATION: {{staging-cf-organization}}
+      CF_SPACE: {{staging-cf-space}}
       BROKER_NAME: {{staging-broker-name}}
       AUTH_USER: {{staging-auth-user}}
       AUTH_PASS: {{staging-auth-pass}}
@@ -315,7 +341,11 @@ jobs:
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
     params:
-      <<: *staging-cf-creds
+      CF_API_URL: {{staging-cf-api-url}}
+      CF_USERNAME: {{staging-cf-deploy-username}}
+      CF_PASSWORD: {{staging-cf-deploy-password}}
+      CF_ORGANIZATION: {{staging-cf-organization}}
+      CF_SPACE: {{staging-cf-space}}
       BROKER_NAME: {{staging-broker-name}}
       AUTH_USER: {{staging-auth-user}}
       AUTH_PASS: {{staging-auth-pass}}
@@ -324,49 +354,67 @@ jobs:
 
 - name: acceptance-tests-staging
   plan:
-  - get: aws-broker-app
-    passed: [deploy-aws-broker-staging]
-    trigger: true
-  - aggregate:
-    - get: sqlclient-oracle-basiclite
-    - get: sqlclient-oracle-sqlplus
-    - get: sqlclient-postgres
-    - get: sqlclient-mysql
-  - aggregate:
-    - task: smoke-tests-postgres
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *staging-cf-creds
-        SERVICE_PLAN: medium-psql
-        DB_TYPE: postgres
+  - in_parallel:
+    - get: aws-broker-app
+      passed: [deploy-aws-broker-staging]
+      trigger: true
+    - get: aws-db-test
+  - in_parallel:
+      steps:
+      - task: smoke-tests-postgres
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{staging-cf-api-url}}
+          CF_USERNAME: {{staging-cf-deploy-username}}
+          CF_PASSWORD: {{staging-cf-deploy-password}}
+          CF_ORGANIZATION: {{staging-cf-organization}}
+          CF_SPACE: {{staging-cf-space}}
+          SERVICE_PLAN: medium-psql
+          DB_TYPE: postgres
 
-    - task: smoke-tests-shared-postgres
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *staging-cf-creds
-        SERVICE_PLAN: shared-psql
-        DB_TYPE: postgres
+      - task: smoke-tests-shared-postgres
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{staging-cf-api-url}}
+          CF_USERNAME: {{staging-cf-deploy-username}}
+          CF_PASSWORD: {{staging-cf-deploy-password}}
+          CF_ORGANIZATION: {{staging-cf-organization}}
+          CF_SPACE: {{staging-cf-space}}
+          SERVICE_PLAN: shared-psql
+          DB_TYPE: postgres
 
-    - task: smoke-tests-mysql
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *staging-cf-creds
-        SERVICE_PLAN: medium-mysql
-        DB_TYPE: mysql
+      - task: smoke-tests-mysql
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{staging-cf-api-url}}
+          CF_USERNAME: {{staging-cf-deploy-username}}
+          CF_PASSWORD: {{staging-cf-deploy-password}}
+          CF_ORGANIZATION: {{staging-cf-organization}}
+          CF_SPACE: {{staging-cf-space}}
+          SERVICE_PLAN: medium-mysql
+          DB_TYPE: mysql
 
-    - task: smoke-tests-shared-mysql
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *staging-cf-creds
-        SERVICE_PLAN: shared-mysql
-        DB_TYPE: mysql
+      - task: smoke-tests-shared-mysql
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{staging-cf-api-url}}
+          CF_USERNAME: {{staging-cf-deploy-username}}
+          CF_PASSWORD: {{staging-cf-deploy-password}}
+          CF_ORGANIZATION: {{staging-cf-organization}}
+          CF_SPACE: {{staging-cf-space}}
+          SERVICE_PLAN: shared-mysql
+          DB_TYPE: mysql
 
-    - task: smoke-tests-oracle
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *staging-cf-creds
-        SERVICE_PLAN: medium-oracle-se2
-        DB_TYPE: oracle-se2
+      - task: smoke-tests-oracle
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{staging-cf-api-url}}
+          CF_USERNAME: {{staging-cf-deploy-username}}
+          CF_PASSWORD: {{staging-cf-deploy-password}}
+          CF_ORGANIZATION: {{staging-cf-organization}}
+          CF_SPACE: {{staging-cf-space}}
+          SERVICE_PLAN: medium-oracle-se2
+          DB_TYPE: oracle-se2
   on_success:
     put: slack
     params:
@@ -387,7 +435,7 @@ jobs:
       icon_url: {{slack-icon-url}}
 - name: deploy-aws-broker-prod
   plan:
-  - aggregate:
+  - in_parallel:
     - get: aws-broker-app
       passed: [acceptance-tests-staging]
       trigger: true
@@ -495,7 +543,11 @@ jobs:
   - task: update-broker
     file: pipeline-tasks/register-service-broker.yml
     params:
-      <<: *prod-cf-creds
+      CF_API_URL: {{prod-cf-api-url}}
+      CF_USERNAME: {{prod-cf-deploy-username}}
+      CF_PASSWORD: {{prod-cf-deploy-password}}
+      CF_ORGANIZATION: {{prod-cf-organization}}
+      CF_SPACE: {{prod-cf-space}}
       BROKER_NAME: {{prod-broker-name}}
       AUTH_USER: {{prod-auth-user}}
       AUTH_PASS: {{prod-auth-pass}}
@@ -504,7 +556,11 @@ jobs:
   - task: update-broker-enterprise
     file: pipeline-tasks/register-service-broker.yml
     params:
-      <<: *prod-cf-creds
+      CF_API_URL: {{prod-cf-api-url}}
+      CF_USERNAME: {{prod-cf-deploy-username}}
+      CF_PASSWORD: {{prod-cf-deploy-password}}
+      CF_ORGANIZATION: {{prod-cf-organization}}
+      CF_SPACE: {{prod-cf-space}}
       BROKER_NAME: {{prod-broker-name}}
       AUTH_USER: {{prod-auth-user}}
       AUTH_PASS: {{prod-auth-pass}}
@@ -513,49 +569,67 @@ jobs:
 
 - name: acceptance-tests-prod
   plan:
-  - get: aws-broker-app
-    passed: [deploy-aws-broker-prod]
-    trigger: true
-  - aggregate:
-    - get: sqlclient-oracle-basiclite
-    - get: sqlclient-oracle-sqlplus
-    - get: sqlclient-postgres
-    - get: sqlclient-mysql
-  - aggregate:
-    - task: smoke-tests-postgres
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *prod-cf-creds
-        SERVICE_PLAN: medium-psql
-        DB_TYPE: postgres
+  - in_parallel: 
+    - get: aws-broker-app
+      passed: [deploy-aws-broker-prod]
+      trigger: true
+    - get: aws-db-test
+  - in_parallel:
+      steps:
+      - task: smoke-tests-postgres
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{prod-cf-api-url}}
+          CF_USERNAME: {{prod-cf-deploy-username}}
+          CF_PASSWORD: {{prod-cf-deploy-password}}
+          CF_ORGANIZATION: {{prod-cf-organization}}
+          CF_SPACE: {{prod-cf-space}}
+          SERVICE_PLAN: medium-psql
+          DB_TYPE: postgres
 
-    - task: smoke-tests-shared-postgres
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *prod-cf-creds
-        SERVICE_PLAN: shared-psql
-        DB_TYPE: postgres
+      - task: smoke-tests-shared-postgres
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{prod-cf-api-url}}
+          CF_USERNAME: {{prod-cf-deploy-username}}
+          CF_PASSWORD: {{prod-cf-deploy-password}}
+          CF_ORGANIZATION: {{prod-cf-organization}}
+          CF_SPACE: {{prod-cf-space}}
+          SERVICE_PLAN: shared-psql
+          DB_TYPE: postgres
 
-    - task: smoke-tests-mysql
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *prod-cf-creds
-        SERVICE_PLAN: medium-mysql
-        DB_TYPE: mysql
+      - task: smoke-tests-mysql
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{prod-cf-api-url}}
+          CF_USERNAME: {{prod-cf-deploy-username}}
+          CF_PASSWORD: {{prod-cf-deploy-password}}
+          CF_ORGANIZATION: {{prod-cf-organization}}
+          CF_SPACE: {{prod-cf-space}}
+          SERVICE_PLAN: medium-mysql
+          DB_TYPE: mysql
 
-    - task: smoke-tests-shared-mysql
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *prod-cf-creds
-        SERVICE_PLAN: shared-mysql
-        DB_TYPE: mysql
+      - task: smoke-tests-shared-mysql
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{prod-cf-api-url}}
+          CF_USERNAME: {{prod-cf-deploy-username}}
+          CF_PASSWORD: {{prod-cf-deploy-password}}
+          CF_ORGANIZATION: {{prod-cf-organization}}
+          CF_SPACE: {{prod-cf-space}}
+          SERVICE_PLAN: shared-mysql
+          DB_TYPE: mysql
 
-    - task: smoke-tests-oracle
-      file: aws-broker-app/ci/run-smoke-tests.yml
-      params:
-        <<: *prod-cf-creds
-        SERVICE_PLAN: medium-oracle-se2
-        DB_TYPE: oracle-se2
+      - task: smoke-tests-oracle
+        file: aws-broker-app/ci/run-smoke-tests.yml
+        params:
+          CF_API_URL: {{prod-cf-api-url}}
+          CF_USERNAME: {{prod-cf-deploy-username}}
+          CF_PASSWORD: {{prod-cf-deploy-password}}
+          CF_ORGANIZATION: {{prod-cf-organization}}
+          CF_SPACE: {{prod-cf-space}}
+          SERVICE_PLAN: medium-oracle-se2
+          DB_TYPE: oracle-se2
   on_success:
     put: slack
     params:
@@ -594,6 +668,12 @@ resources:
     uri: {{aws-broker-url-development}}
     branch: {{aws-broker-branch-development}}
 
+- name: aws-db-test
+  type: git
+  source:
+    uri: {{aws-db-test-git-url}}
+    branch: {{aws-db-test-git-branch}}
+
 - name: deploy-aws-broker-development
   type: cf
   source:
@@ -629,34 +709,6 @@ resources:
   source:
     url: {{slack-webhook-url}}
 
-- name: sqlclient-oracle-basiclite
-  type: s3-iam
-  source:
-    region_name: {{binaries-aws-region}}
-    regexp: sql-client-binaries\/instantclient-basiclite-(.*).zip
-    bucket: {{cg-s3-binaries-bucket}}
-
-- name: sqlclient-oracle-sqlplus
-  type: s3-iam
-  source:
-    region_name: {{binaries-aws-region}}
-    regexp: sql-client-binaries\/instantclient-sqlplus-(.*).zip
-    bucket: {{cg-s3-binaries-bucket}}
-
-- name: sqlclient-postgres
-  type: s3-iam
-  source:
-    region_name: {{binaries-aws-region}}
-    regexp: sql-client-binaries\/psql-(.*)-ubuntu-(.*).tar.gz
-    bucket: {{cg-s3-binaries-bucket}}
-
-- name: sqlclient-mysql
-  type: s3-iam
-  source:
-    region_name: {{binaries-aws-region}}
-    regexp: sql-client-binaries\/mysql-(.*).gz
-    bucket: {{cg-s3-binaries-bucket}}
-
 resource_types:
 - name: slack-notification
   type: docker-image
@@ -667,24 +719,3 @@ resource_types:
   type: docker-image
   source:
     repository: 18fgsa/s3-resource
-
-development-cf-creds: &development-cf-creds
-  CF_API_URL: {{development-cf-api-url}}
-  CF_USERNAME: {{development-cf-deploy-username}}
-  CF_PASSWORD: {{development-cf-deploy-password}}
-  CF_ORGANIZATION: {{development-cf-organization}}
-  CF_SPACE: {{development-cf-space}}
-
-staging-cf-creds: &staging-cf-creds
-  CF_API_URL: {{staging-cf-api-url}}
-  CF_USERNAME: {{staging-cf-deploy-username}}
-  CF_PASSWORD: {{staging-cf-deploy-password}}
-  CF_ORGANIZATION: {{staging-cf-organization}}
-  CF_SPACE: {{staging-cf-space}}
-
-prod-cf-creds: &prod-cf-creds
-  CF_API_URL: {{prod-cf-api-url}}
-  CF_USERNAME: {{prod-cf-deploy-username}}
-  CF_PASSWORD: {{prod-cf-deploy-password}}
-  CF_ORGANIZATION: {{prod-cf-organization}}
-  CF_SPACE: {{prod-cf-space}}

--- a/ci/run-smoke-tests.sh
+++ b/ci/run-smoke-tests.sh
@@ -2,66 +2,42 @@
 
 set -eux
 
+# todo (mxplusb): update the auth mechanism.
 cf login -a $CF_API_URL -u $CF_USERNAME -p $CF_PASSWORD -o $CF_ORGANIZATION -s $CF_SPACE
 
 # Clean up existing app and service if present
 cf delete -f smoke-tests-$SERVICE_PLAN
 cf delete-service -f rds-smoke-tests-$SERVICE_PLAN
 
+# change into the directory and push the app without starting it.
+pushd aws-db-test/databases/aws-rds
+cf push "smoke-tests-${SERVICE_PLAN}" -f manifest.yml --no-start
+
+# set some variables that it needs
+cf set-env "smoke-tests-${SERVICE_PLAN}" DB_TYPE "${SERVICE_PLAN}"
+cf set-env "smoke-tests-${SERVICE_PLAN}" SERVICE_NAME "rds-smoke-tests-$SERVICE_PLAN"
+
 # Create service
 if echo "$SERVICE_PLAN" | grep -v shared | grep mysql >/dev/null ; then
   # test out the enable_functions stuff, which only works on non-shared mysql databases
   cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-$SERVICE_PLAN" -c '{"enable_functions": true}'
-
-  # Write manifest with ENABLE_FUNCTIONS set so that we can test for it
-  cat << EOF > aws-broker-app/ci/smoke-tests/manifest.yml
----
-applications:
-- name: smoke-tests-${SERVICE_PLAN}
-  buildpack: binary_buildpack
-  command: ./smoke-tests.sh
-  env:
-    DB_TYPE: ${DB_TYPE}
-    ENABLE_FUNCTIONS: true
-  services:
-  - rds-smoke-tests-${SERVICE_PLAN}
-EOF
 else
   # create a regular instance
   cf create-service aws-rds "$SERVICE_PLAN" "rds-smoke-tests-$SERVICE_PLAN"
-
-  # Write manifest
-  cat << EOF > aws-broker-app/ci/smoke-tests/manifest.yml
----
-applications:
-- name: smoke-tests-${SERVICE_PLAN}
-  buildpack: binary_buildpack
-  command: ./smoke-tests.sh
-  env:
-    DB_TYPE: ${DB_TYPE}
-  services:
-  - rds-smoke-tests-${SERVICE_PLAN}
-EOF
 fi
 
-
-
-cp -R sqlclient-oracle-basiclite aws-broker-app/ci/smoke-tests/.
-cp -R sqlclient-oracle-sqlplus aws-broker-app/ci/smoke-tests/.
-cp -R sqlclient-postgres aws-broker-app/ci/smoke-tests/.
-cp -R sqlclient-mysql aws-broker-app/ci/smoke-tests/.
-
-# Wait until service is available
 while true; do
-  if out=$(cf push -f aws-broker-app/ci/smoke-tests/manifest.yml -p aws-broker-app/ci/smoke-tests 2>&1); then
+  if out=$(cf bind-service "smoke-tests-${SERVICE_PLAN}" "rds-smoke-tests-$SERVICE_PLAN"); then
     break
   fi
-  if ! [[ $out =~ "Instance not available yet" ]]; then
+  if [[ $out =~ "Instance not available yet" ]]; then
     echo "${out}"
-    exit 1
   fi
   sleep 90
 done
+
+# wait for the app to start. if the app starts, it's passed the smoke test.
+cf push "smoke-tests-${SERVICE_PLAN}" 
 
 # Clean up app and service
 cf delete -f smoke-tests-$SERVICE_PLAN

--- a/ci/run-smoke-tests.yml
+++ b/ci/run-smoke-tests.yml
@@ -4,14 +4,11 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: 18fgsa/concourse-task
+    repository: 18fgsa/sql-clients
 
 inputs:
 - name: aws-broker-app
-- name: sqlclient-oracle-basiclite
-- name: sqlclient-oracle-sqlplus
-- name: sqlclient-postgres
-- name: sqlclient-mysql
+- name: aws-db-test
 
 run:
   path: aws-broker-app/ci/run-smoke-tests.sh

--- a/ci/run_tests.yml
+++ b/ci/run_tests.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.8-wheezy
+    tag: latest
 
 inputs:
 - name: aws-broker-app

--- a/ci/smoke-tests/smoke-tests.sh
+++ b/ci/smoke-tests/smoke-tests.sh
@@ -2,50 +2,25 @@
 
 set -e -x
 
-curl -O -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-JQ=./jq-linux64
-chmod +x $JQ
-
 if [ $DB_TYPE = "postgres" ] ; then
-  tar -xvzf $(find sqlclient-postgres -type f -name "psql*")
-  ./psql/bin/psql $DATABASE_URL -c "create table smoke (id integer, name text);"
-  ./psql/bin/psql $DATABASE_URL -c "insert into smoke values (1, 'smoke');"
-  ./psql/bin/psql $DATABASE_URL -c "drop table smoke;"
+
+  psql $DATABASE_URL -c "create table smoke (id integer, name text);"
+  psql $DATABASE_URL -c "insert into smoke values (1, 'smoke');"
+  psql $DATABASE_URL -c "drop table smoke;"
+
 elif [ $DB_TYPE = "mysql" ] ; then
-  gunzip -c $(find sqlclient-mysql -type f -name "mysql*") > mysql
-  chmod +x ./mysql
-  MYSQL_HOST=`echo $VCAP_SERVICES | $JQ -c -r '.["aws-rds"] | .[0].credentials.host'`
-  MYSQL_USER=`echo $VCAP_SERVICES | $JQ -c -r '.["aws-rds"] | .[0].credentials.username'`
-  MYSQL_PASS=`echo $VCAP_SERVICES | $JQ -c -r '.["aws-rds"] | .[0].credentials.password'`
-  MYSQL_DB=`echo $VCAP_SERVICES | $JQ -c -r '.["aws-rds"] | .[0].credentials.db_name'`
-  ./mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASS -e "create table smoke (id integer, name text);" $MYSQL_DB
-  ./mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASS -e "insert into smoke values (1, 'smoke');" $MYSQL_DB
-  ./mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASS -e "drop table smoke;" $MYSQL_DB
-  if [ -n "$ENABLE_FUNCTIONS" ] ; then
-    ./mysql -h "$MYSQL_HOST" -u "$MYSQL_USER" -p"$MYSQL_PASS" -e "create function hello(id INT) returns CHAR(50) return 'foobar';" "$MYSQL_DB"
-  fi
-elif [ $DB_TYPE = "oracle-se1" ] || [ $DB_TYPE = "oracle-se2" ] || [ $DB_TYPE = "oracle-ee" ] ; then
-  unzip $(find sqlclient-oracle-basiclite -type f -name "instantclient*")
-  unzip $(find sqlclient-oracle-sqlplus -type f -name "instantclient*")
-  ORCL_PATH=$(find . -type d -name "instantclient*")
-  SQL_HOST=$(echo $VCAP_SERVICES | $JQ -r '."aws-rds"[0].credentials.host')
-  SQL_USER=$(echo $VCAP_SERVICES | $JQ -r '."aws-rds"[0].credentials.username')
-  SQL_PASS=$(echo $VCAP_SERVICES | $JQ -r '."aws-rds"[0].credentials.password')
-  SQL_DB=$(echo $VCAP_SERVICES | $JQ -r '."aws-rds"[0].credentials.db_name')
-  # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ConnectToOracleInstance.html notes
-  # that this connection string may fail if SQL_HOST string is > 63 chars, but
-  # works OK with 80 chars in testing
-  export LD_LIBRARY_PATH="/home/vcap/app/${ORCL_PATH}"
-  cat <<END_SMOKE > smoke.sql
-WHENEVER SQLERROR EXIT SQL.SQLCODE
-CREATE TABLE smoke (id integer, name varchar2(10));
-INSERT INTO smoke VALUES (1, 'smoke');
-DROP TABLE smoke;
-EXIT;
-END_SMOKE
-$ORCL_PATH/sqlplus -S "${SQL_USER}/${SQL_PASS}@${SQL_HOST}:1521/$SQL_DB" @smoke.sql
+
+  MYSQL_HOST=`echo $VCAP_SERVICES | jq -c -r '.["aws-rds"] | .[0].credentials.host'`
+  MYSQL_USER=`echo $VCAP_SERVICES | jq -c -r '.["aws-rds"] | .[0].credentials.username'`
+  MYSQL_PASS=`echo $VCAP_SERVICES | jq -c -r '.["aws-rds"] | .[0].credentials.password'`
+  MYSQL_DB=`echo $VCAP_SERVICES | jq -c -r '.["aws-rds"] | .[0].credentials.db_name'`
+  mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASS -e "insert into smoke values (1, 'smoke');" $MYSQL_DB
+  mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASS -e "create table smoke (id integer, name text);" $MYSQL_DB
+  mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASS -e "drop table smoke;" $MYSQL_DB
+  mysql -h $MYSQL_HOST -u $MYSQL_USER -p$MYSQL_PASS -e "create function hello(id INT) returns CHAR(50) return 'foobar';" $MYSQL_DB
+  
 else
-  echo "\$DB_TYPE must be one of: postgres mysql oracle-se1" # oracle-se2 oracle-ee
+  echo "\$DB_TYPE must be one of: postgres mysql" #
   exit 1
 fi
 

--- a/services/rds/rds.go
+++ b/services/rds/rds.go
@@ -107,7 +107,7 @@ type dedicatedDBAdapter struct {
 }
 
 // This is the prefix for all pgroups created by the broker.
-const PgroupPrefix = "awsbroker-pgroup-"
+const PgroupPrefix = "cg-aws-broker-"
 
 // This function will return the a custom parameter group with whatever custom parameters
 // have been requested.  If there is no custom parameter group, it will be created.


### PR DESCRIPTION
[Green Build](https://ci.fr.cloud.gov/teams/main/pipelines/deploy-aws-broker/jobs/acceptance-tests-prod/builds/32)

* updated `aggregate` to `in_parallel`

* removed yaml anchors, not working in concourse 5.x.

* smoke tests now use 18f/cg-labratory/databases/aws-rds db verification
app. it migrates the smoke tests from self-compiled shell scripts to a
golang app, which includes the supported database drivers. the app
replicates the shell scripts, using the same SQL statements, so they are
functionally the same. by updating this, it removes the dependencies on
self-compiled shell scripts, and the aws-rds app can be manually pushed,
if needed.

* removed the self-compiled shell scripts for various db clients.

* smoke tests now push a non-started version of aws-rds, set environment
variables to reflect the database configs, bind the service, then
re-push to stage the app.

* pipeline now runs on 18fgsa/sql-clients container image, which is used
for troubleshooting issues with rds dbs, it has all the requisite
clients needed.

* updated golang image from 1.8-wheezy to latest.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>

//cc @timothy-spencer 